### PR TITLE
Set time for current day to 12 to avoid tz issue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -148,7 +148,8 @@ class WeatherSkill(MycroftSkill):
 
             # Get forecast for the day
             # can get 'min', 'max', 'eve', 'morn', 'night', 'day'
-            forecastWeather = self.__get_forecast(today,
+            # Set time to 12 instead of 00 to accomodate for timezones
+            forecastWeather = self.__get_forecast(today.replace(hour=12),
                                                   report['full_location'])
             LOG.debug("Forecast: " + str(forecastWeather.to_JSON()))
             report['temp_min'] = self.__get_temperature(forecastWeather, 'min')


### PR DESCRIPTION
==== Fixes ====
#7 

====  Tech Notes  ====
The previously used datetime for getting current day: YYYY-MM-DD 00:00
caused problems for timezones on the + side of GMT due to the
recalculation to GMT. Sweden for example is GMT +1 which when recalculated
yields the datetime YYYY-MM-DD-1 23:00 (i.e. 23:00 the previous day).
OWM forecast doesn't work for previous days. and causes an error.

Setting the time to 12:00 should work in all cases and since for both
positive and  negative timezones.