### PR TITLE
Add ability to override unit for Weather only

### DIFF
--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,0 +1,22 @@
+{
+    "name": "Mycroft Weather",
+    "skillMetadata": {
+        "sections": [
+            {
+                "name": "Options",
+                "fields": [
+                    {
+                        "type": "label",
+                        "label": "By default the weather will be reported in farenheit if <tt>U.S. Units</tt> are selected and celsius if <tt>Metric</tt> units are chosen under the Units of Measurement setting at <a href='https://home.mycroft.ai/#/setting/basic'>Mycroft Home</a>.  You many also override this unit here.  Legal values are: <ul><li>default</li><li>celsius or c</li><li>farenheit or f</li></ul>"
+                    },
+                    {
+                        "name": "units",
+                        "type": "text",
+                        "label": "Temperature units",
+                        "value": "default"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
In a few places in the world the metric system is used but the temperature
is still commonly spoken of in Farenheit units.  This change allows users
to override the Metric/US setting to deal with this.

Also removed some leftover debug logs and switched to using self.log.