### PR TITLE
Fix sticky weather display

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -505,6 +505,7 @@ class WeatherSkill(MycroftSkill):
         # Just show the icons while still speaking
         mycroft.audio.wait_while_speaking()
         self.enclosure.activate_mouth_events()
+        self.enclosure.mouth_reset()
 
     def __report_condition(self, name, value, when):
         # Report a specific value


### PR DESCRIPTION
The display for the weather skill was staying on screen indefinitely.
This appears to be the result of a change that fixed the
wait_while_speaking() command, so now it actually _does_ wait.
Before that it would pass on prematurely, calling reset_mouth() when
finished with TTS output.