### PR TITLE
Clarify localization

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -51,6 +51,10 @@ class OWMApi(Api):
 
     def __init__(self):
         super(OWMApi, self).__init__("owm")
+        # This is the language code for the interaction between python and the
+        # OpenWeatherMap API. This value does not need to be localized as data is fetched
+        # in English from the OWM API and later on translated at the WeatherSkill
+        # class:
         self.lang = "en"
         self.observation = ObservationParser()
         self.forecast = ForecastParser()


### PR DESCRIPTION
The class that interacts with Openweather does not need to be localized, as the translation is done at the WeatherSkill level.

This is a common question by the translation teams, so it is worth the clarification.