### PR TITLE
Changes to support improved extract_datetime()

### DIFF
--- a/test/intent/000.what-is-weather.json
+++ b/test/intent/000.what-is-weather.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "what is the weather like",
+    "intent_type": "handle_current_weather",
+    "expected_dialog": "current.local.weather"
+}

--- a/test/intent/001.what-is-weather-forecast.json
+++ b/test/intent/001.what-is-weather-forecast.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "what is the forecast",
+    "intent_type": "handle_forecast",
+    "expected_dialog": "forecast.local.weather"
+}

--- a/test/intent/002.when-will-it-rain-next.json
+++ b/test/intent/002.when-will-it-rain-next.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "when will it rain next",
+    "intent_type": "handle_next_precipitation",
+    "expected_dialog": "precipitation expected"
+}

--- a/test/intent/003.what-will-weather-be-later.json
+++ b/test/intent/003.what-will-weather-be-later.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "What will the weather be like later",
+    "intent_type": "handle_next_hour",
+    "expected_dialog": "hour.local.weather"
+}

--- a/test/intent/004.how-humid.json
+++ b/test/intent/004.how-humid.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "How humid is it",
+    "intent_type": "handle_humidity",
+    "expected_dialog": "humidity"
+}

--- a/test/intent/005.how-windy.json
+++ b/test/intent/005.how-windy.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "How windy is it",
+    "intent_type": "handle_windy",
+    "expected_dialog": "winds"
+}

--- a/test/intent/006.when-is-sunrise.json
+++ b/test/intent/006.when-is-sunrise.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "When is sunrise",
+    "intent_type": "handle_sunrise",
+    "expected_response": "(one|two|three|four|five|six|seven|eight|nine).*(A|P|a|p)\\.(m|M)\\."
+}

--- a/test/intent/007.when-is-sunset.json
+++ b/test/intent/007.when-is-sunset.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "When is sunset",
+    "intent_type": "handle_sunset",
+    "expected_response": "(one|two|three|four|five|six|seven|eight|nine).*(A|P|a|p)\\.(m|M)\\."
+}

--- a/test/intent/sample1.intent.json
+++ b/test/intent/sample1.intent.json
@@ -1,8 +1,0 @@
-{
-  "utterance": "what's the weather like in stockholm",
-  "intent_type": "CurrentWeatherIntent",
-  "intent": {
-    "Weather": "weather"
-  },
-  "expected_dialog": "current.weather"
-}

--- a/test/intent/sample2.intent.json
+++ b/test/intent/sample2.intent.json
@@ -1,8 +1,0 @@
-{
-  "utterance": "what's the weather like",
-  "intent_type": "CurrentWeatherIntent",
-  "intent": {
-    "Weather": "weather"
-  },
-  "expected_dialog": "current.local.weather"
-}

--- a/test/intent/sample3.intent.json
+++ b/test/intent/sample3.intent.json
@@ -1,8 +1,0 @@
-{
-  "utterance": "what is the weather going to be like tomorrow",
-  "intent_type": "CurrentWeatherIntent",
-  "intent": {
-    "Weather": "weather"
-  },
-  "expected_dialog": "forecast.local.weather"
-}


### PR DESCRIPTION
The new extract_datetime() returns a datetime object that has the tzinfo
properly populated.  This breaks the gymnastics that the WeatherSkill
was using to handle time zones using pytz.

Adding backwards-compatible wrappers for now.  If the new mycroft.util.time
exists, the new standard handling is performed.  Otherwise the old tzinfo
cramming will happen.

Also added new-style autotesting to replace old tests.