### PR TITLE
Bugfix/regex

### DIFF
--- a/dialog/en-us/current.temperature.dialog
+++ b/dialog/en-us/current.temperature.dialog
@@ -1,4 +1,4 @@
-It's currently {{condition}} and {{temp}} degrees {{scale}} in {{location}}. 
-It's currently {{condition}} and {{temp}} degrees in {{location}}.
-Right now, it's {{condition}} and {{temp}} degrees in {{location}}.
+It's currently {{temp}} degrees {{scale}} in {{location}}. 
+It's currently {{temp}} degrees in {{location}}.
+Right now, it's {{temp}} degrees in {{location}}.
 

--- a/regex/en-us/location.rx
+++ b/regex/en-us/location.rx
@@ -1,1 +1,1 @@
-.*\b(at|in) (?P<Location>\b(?!celsius|fahrenheit)\b\S+)
+.*\b(at|in) (?P<Location>(?!\bcelsius\b|\bfahrenheit\b) *.+)


### PR DESCRIPTION
Fix Fahrenheit / Celsius excluding regex. Now multiword names are returned and names starting with Celsius/Fahrenheit will work.