### PR TITLE
compatibility wrapper for nice_time

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1091,7 +1091,7 @@ class WeatherSkill(MycroftSkill):
     def __nice_time(self, dt, lang="en-us", speech=True, use_24hour=False,
                     use_ampm=False):
         # compatibility wrapper for nice_time
-        nt_supported_languages = ['en','it','fr','de']
+        nt_supported_languages = ['en','es','it','fr','de','hu','nl','da']
         if not (lang[0:2] in nt_supported_languages):
             lang = "en-us"
         return nice_time(dt, lang, speech, use_24hour, use_ampm)


### PR DESCRIPTION
Added 'es', 'hu', 'nl' and 'da' to compatibility wrapper for nice_time as these language are now supported as well.