### PR TITLE
Add a bit of safety then preparing cache

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -323,9 +323,13 @@ class WeatherSkill(MycroftSkill):
     def prime_weather_cache(self):
         # If not already cached, this will reach out for current conditions
         report = self.__initialize_report(None)
-        currentWeather = self.owm.weather_at_place(
-            report['full_location'], report['lat'],
-            report['lon']).get_weather()
+        try:
+            self.owm.weather_at_place(
+                report['full_location'], report['lat'],
+                report['lon']).get_weather()
+        except Exception as e:
+            self.log.error('Failed to prime weather cache '
+                           '({})'.format(repr(e)))
 
     def schedule_for_daily_use(self):
         # Assume the user has a semi-regular schedule.  Whenever this method


### PR DESCRIPTION
When device isn't paired or if an HTTP error occurs when preparing the cache the skill would fail to load. This adds the minimal required security to handle this.