### PR TITLE
Fix: Long locations not recursively searching

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -171,6 +171,10 @@ class OWMApi(Api):
                 "path": "/weather",
                 "query": q
             })
+            # 404 returned as JSON-like string not HTTPError in some instances
+            if type(data) is str and'{"cod":"404"' in data:
+                name = ' '.join(name.split()[:-1])
+                return self.weather_at_location(name)
             return self.observation.parse_JSON(data), name
         except HTTPError as e:
             if e.response.status_code == 404:
@@ -1139,7 +1143,7 @@ class WeatherSkill(MycroftSkill):
 
         Arguments:
             message (Message): messagebus message
-        Returns: tuple (lat, long, location string)
+        Returns: tuple (lat, long, location string, pretty location)
         """
         try:
             location = message.data.get("Location", None) if message else None


### PR DESCRIPTION
For some reason a 404 response is sometimes returned as a JSON-like string and doesn't raise a HTTPError thereby avoiding the recursive search. 

I have currently left the existing except block in assuming that this may also trigger depending on the search.

Also small update to the `__get_location` doc string to properly reflect the returned data.

## To test
Ask for the "weather in Sydney Australia" or "weather in Johannesburg South Africa".
Without change - no response.
With change - recursively searches and returns location as Sydney and Johannesburg respectively.