### PR TITLE
do not continue if weather forecast not returned

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1290,6 +1290,8 @@ class WeatherSkill(MycroftSkill):
             report['full_location'],
             report['lat'],
             report['lon'])
+        if not currentWeather or not forecastWeather:
+            return None # No forecast available.
 
         # Change encoding of the localized report to utf8 if needed
         condition = currentWeather.get_detailed_status()


### PR DESCRIPTION
If forecast not returned from OWM then do not attempt to read values from it.

This is a minor quick fix to match the behaviour of the other report types. Have added to the issues list to ensure this is being handled in the best way in the future.