### PR TITLE
fix test failing if run on saturday

### DIFF
--- a/test/intent/10_high-low_004.on-day-how-hot-in-location.json
+++ b/test/intent/10_high-low_004.on-day-how-hot-in-location.json
@@ -1,4 +1,4 @@
 {
-    "utterance": "on saturday how hot in auckland",
-    "expected_dialog": "forecast.temperature"
+    "utterance": "next saturday how hot will it be in auckland",
+    "expected_dialog": "forecast.high.temperature"
 }


### PR DESCRIPTION
Existing test asks for temperature on Saturday and expects a future forecast. 
So if it is run on Saturday, it returns "today's" temp and fails.