### PR TITLE
Remove single keyword intents

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -769,6 +769,10 @@ class WeatherSkill(MycroftSkill):
     def handle_current_temperature(self, message):
         return self.__handle_typed(message, 'temperature')
 
+    @intent_handler('simple.temperature.intent')
+    def handle_simple_temperature(self, message):
+        return self.__handle_typed(message, 'temperature')
+
     @intent_handler(IntentBuilder("").require("Query").require("High")
                     .optionally("Temperature").optionally("Location")
                     .optionally("Unit").optionally("RelativeDay")

--- a/test/intent/09_temperature_001.temperature-simple.json
+++ b/test/intent/09_temperature_001.temperature-simple.json
@@ -1,5 +1,4 @@
 {
     "utterance": "temperature",
-    "intent_type": "handle_current_temperature",
     "expected_dialog": "current.local.temperature"
 }

--- a/vocab/en-us/simple.temperature.intent
+++ b/vocab/en-us/simple.temperature.intent
@@ -1,0 +1,1 @@
+temperature

--- a/vocab/en-us/whats.weather.like.intent
+++ b/vocab/en-us/whats.weather.like.intent
@@ -1,2 +1,5 @@
 what is it like out (today|)
 what is it like outside
+weather
+forecast
+weather forecast


### PR DESCRIPTION
Adapt intents should have at least two keywords required (including `one_of`) to prevent irrelevant utterances matching.

Any necessary single term utterances should be added to a Padatious intent.