### PR TITLE
Re-add local pyown usage with local api-key. Refactored OWNApi into …

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,7 @@ from mycroft.util.parse import extract_datetime, extract_number
 from pyowm.webapi25.forecaster import Forecaster
 from pyowm.webapi25.forecastparser import ForecastParser
 from pyowm.webapi25.observationparser import ObservationParser
+from pyowm import OWM
 from requests import HTTPError, Response
 
 try:
@@ -80,9 +81,10 @@ WINDSTRENGTH_MPS = {
 
 class OWMApi(Api):
     ''' Wrapper that defaults to the Mycroft cloud proxy so user's don't need
-        to get their own OWM API keys '''
+        to get their own OWM API keys.
+        However it also handles a local OWM api_key.'''
 
-    def __init__(self):
+    def __init__(self, api_key, use_proxy):
         super(OWMApi, self).__init__("owm")
         self.owmlang = "en"
         self.encoding = "utf8"
@@ -90,6 +92,12 @@ class OWMApi(Api):
         self.forecast = ForecastParser()
         self.query_cache = {}
         self.location_translations = {}
+
+        if api_key and not use_proxy:
+            self.owm = OWM(api_key)
+        else:
+            self.owm = None
+
 
     @staticmethod
     def get_language(lang):
@@ -137,6 +145,7 @@ class OWMApi(Api):
 
     def request(self, data):
         """ Caching the responses """
+        # request is not used for local_api key
         req_hash = hash(json.dumps(data, sort_keys=True))
         cache = self.query_cache.get(req_hash, (0, None))
         # check for caches with more days data than requested
@@ -170,6 +179,9 @@ class OWMApi(Api):
         if name == '':
             raise LocationNotFoundError('The location couldn\'t be found')
 
+        if self.owm is not None:
+            return self.owm.weather_at_location(name)
+
         q = {"q": name}
         try:
             data = self.request({
@@ -185,10 +197,14 @@ class OWMApi(Api):
 
     def weather_at_place(self, name, lat, lon):
         if lat and lon:
+            if self.owm is not None:
+                return self.owm.weather_at_coords(lat, lon)
             q = {"lat": lat, "lon": lon}
         else:
             if name in self.location_translations:
                 name = self.location_translations[name]
+            if self.owm is not None:
+                return self.owm.weather_at_place(name)
             response, trans_name = self.weather_at_location(name)
             self.location_translations[name] = trans_name
             return response
@@ -201,10 +217,14 @@ class OWMApi(Api):
 
     def three_hours_forecast(self, name, lat, lon):
         if lat and lon:
+            if self.owm is not None:
+                return self.owm.three_hours_forecast_at_coords(lat, lon)
             q = {"lat": lat, "lon": lon}
         else:
             if name in self.location_translations:
                 name = self.location_translations[name]
+            if self.owm is not None:
+                return self.owm.three_hours_forecast(name)
             q = {"q": name}
 
         data = self.request({
@@ -239,7 +259,11 @@ class OWMApi(Api):
     def daily_forecast(self, name, lat, lon, limit=None):
         if lat and lon:
             q = {"lat": lat, "lon": lon}
+            if self.owm is not None:
+                return self.owm.daily_forecast_at_coords(lat, lon)
         else:
+            if self.owm is not None:
+                return self.owm.daily_forecast(name, limit)
             return self._daily_forecast_at_location(name, limit)
 
         if limit is not None:
@@ -268,6 +292,8 @@ class OWMApi(Api):
             'se': 'latin1'
         }
         self.encoding = encodings.get(lang, 'utf8')
+        if self.owm is not None:
+            self.owm.set_language(lang)
 
 
 class WeatherSkill(MycroftSkill):
@@ -288,22 +314,18 @@ class WeatherSkill(MycroftSkill):
         self.CODES['50d', '50n'] = 7                # windy/misty
 
         # Use Mycroft proxy if no private key provided
-        self.settings["api_key"] = None
-        self.settings["use_proxy"] = True
+        self.settings.setdefault("api_key", None)
+        self.settings.setdefault("use_proxy", True)
 
     def initialize(self):
-        # TODO: Remove lat,lon parameters from the OWMApi()
-        #       methods and implement _at_coords() versions
-        #       instead to make the interfaces compatible
-        #       again.
-        #
-        # if self.settings["api_key"] and not self.settings['use_proxy']):
-        #     self.owm = OWM(self.settings["api_key"])
-        # else:
-        #     self.owm = OWMApi()
-        self.owm = OWMApi()
+        # lat,lon parameters are handled by OWMApi() both for
+        # local api key and mycrodt's api
+
+        self.owm = OWMApi( self.settings["api_key"], self.settings['use_proxy'] )
+
         if self.owm:
             self.owm.set_OWM_language(lang=OWMApi.get_language(self.lang))
+
 
         self.schedule_for_daily_use()
         try:


### PR DESCRIPTION
…real wrapper that can use local api_key or default to doing web requests to mycroft.

As discussed with @forslund in the forums.

This allows the weather skill to use a personal OWM api_key (at least when set in local settings.json) and if proxy is set to false.

This effort is probably duplicating issue #27.

Building a connector adapter (that itself could use for example mqtt) into this wrapper might also address issues #98, #100, #115 