### PR TITLE
Add temperature at time VK test

### DIFF
--- a/test/behave/weather-local.feature
+++ b/test/behave/weather-local.feature
@@ -224,3 +224,16 @@ Feature: Mycroft Weather Skill local forecasts and temperature
     | what is the low temperature for next wednesday |
     | what is the low temperature for next saturday |
     | what is the low temperature 5 days from now |
+
+  @xfail
+  Scenario Outline: what is the temperature at a certain time
+    Given an english speaking user
+     When the user says "<what is the temperature at a certain time>"
+     Then "mycroft-weather" should reply with dialog from "at.time.local.temperature.dialog"
+
+  Examples: what is the temperature at a certain time
+    | what is the temperature at a certain time |
+    | what will the temperature be tonight |
+    | what will the temperature be this evening |
+    | what is the temperature this morning |
+    | temperature in the afternoon |

--- a/test/intent/09_temperature_003.what-will-be-the-temperature-tonight.json
+++ b/test/intent/09_temperature_003.what-will-be-the-temperature-tonight.json
@@ -1,5 +1,0 @@
-{
-    "utterance": "what will the temperature be tonight",
-    "intent_type": "handle_current_temperature",
-    "expected_dialog": "at.time.local.temperature"
-}


### PR DESCRIPTION
This removes the old integration test that fails at certain times of the day and adds a number of variations of that same test to the new VK test suite.

It is tagged with `@xfail` to prevent blocking of PR's. 

Skill requires refactor and deeper fix. 