### PR TITLE
Correct handling of "today" to support foreign languages

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1262,7 +1262,7 @@ class WeatherSkill(MycroftSkill):
     def __populate_report(self, message):
         unit = self.__get_requested_unit(message)
         # Get a date from requests like "weather for next Tuesday"
-        today, _ = self.__extract_datetime("today")
+        today, _ = self.__extract_datetime("today", lang='en')
         when, _ = self.__extract_datetime(
                     message.data.get('utterance'), lang=self.lang)
         when = when or today # Get todays date if None was found
@@ -1379,7 +1379,7 @@ class WeatherSkill(MycroftSkill):
 
         wind = self.get_wind_speed(forecastWeather)
         report['wind'] = "{} {}".format(wind[0], wind[1] or "")
-        report['day'] = self.__to_day(extract_datetime('today')[0],
+        report['day'] = self.__to_day(self.__extract_datetime("today", lang='en')[0],
                                       preface=True)
 
         return report


### PR DESCRIPTION
Resolves Nonetype Error that occurs for other languages than English (https://github.com/MycroftAI/skill-weather/issues/138).
"today" in __populate_report should be passed with English language (lang='en'), otherwise it is defined as None, if another language is used as default.
The same applies to "today" in ___populate_current, where self.__extract_datetime should be used with English as language.