### PR TITLE
Handle temperature exactly 0 degrees

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1729,7 +1729,7 @@ class WeatherSkill(MycroftSkill):
             unit = unit or self.__get_temperature_unit()
             # fallback to general temperature if missing
             temp = weather.get_temperature(unit)[key]
-            if temp:
+            if temp is not None:
                 return str(int(round(temp)))
             else:
                 return ''


### PR DESCRIPTION
#### Description
This friday my Mark-1 gave a slightly odd answer when asked about the weather conditions, "... and degrees." he said and showed a screen with the snowflake symbol but no number.

Seems like the criteria is a bit too general and will consider a temperature of `0` as a false value and replace it with the empty string.

This PR corrects the behavior here, checking explicitly for `None` instead.


#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements