### PR TITLE
Fix OWM language selection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -121,10 +121,11 @@ class OWMApi(Api):
                         'es', 'tr', 'ua', 'vi']
 
         if lang[0] in owmsupported:
-            owmlang = lang[0]
+            return lang[0]
+
         if (len(lang) == 2):
             if lang[1] in owmsupported:
-                owmlang = lang[1]
+                return lang[1]
         return owmlang
 
     def build_query(self, params):


### PR DESCRIPTION
When setting mycroft to `ca-es` this skill returns part of the utterance in catalan and part in spanish (the spanish comes directly from the OWM api).

`self.lang` refers to the language set in mycroft.conf, a BCP-47 language tag. The first part of the tag refers to the language
which should have preference if supported by OWM. The second part of the tag is the region, which should not be used as a language but might still be a better fallback than english.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements
