### PR TITLE
fix condition/.. requests with location information

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -419,7 +419,7 @@ class WeatherSkill(MycroftSkill):
         self._report_weather_condition(message, "clouds")
 
     @intent_handler(
-        IntentBuilder("").require("ConfirmQuery").require("Fog").optionally("Location")
+        IntentBuilder("").require("ConfirmQuery").require("Fog").optionally("location")
     )
     def handle_is_it_foggy(self, message: Message):
         """Handler for weather requests such as: is it foggy today?
@@ -430,7 +430,7 @@ class WeatherSkill(MycroftSkill):
         self._report_weather_condition(message, "fog")
 
     @intent_handler(
-        IntentBuilder("").require("ConfirmQuery").require("Rain").optionally("Location")
+        IntentBuilder("").require("ConfirmQuery").require("Rain").optionally("location")
     )
     def handle_is_it_raining(self, message: Message):
         """Handler for weather requests such as: is it raining today?
@@ -453,7 +453,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("ConfirmQuery")
         .require("Thunderstorm")
-        .optionally("Location")
+        .optionally("location")
     )
     def handle_is_it_storming(self, message: Message):
         """Handler for weather requests such as:  is it storming today?
@@ -468,7 +468,7 @@ class WeatherSkill(MycroftSkill):
         .require("When")
         .optionally("Next")
         .require("Precipitation")
-        .optionally("Location")
+        .optionally("location")
     )
     def handle_next_precipitation(self, message: Message):
         """Handler for weather requests such as: when will it rain next?
@@ -495,7 +495,7 @@ class WeatherSkill(MycroftSkill):
         .require("Query")
         .require("Humidity")
         .optionally("RelativeDay")
-        .optionally("Location")
+        .optionally("location")
     )
     def handle_humidity(self, message: Message):
         """Handler for weather requests such as: how humid is it?
@@ -520,7 +520,7 @@ class WeatherSkill(MycroftSkill):
     @intent_handler(
         IntentBuilder("")
         .one_of("Query", "When")
-        .optionally("Location")
+        .optionally("location")
         .require("Sunrise")
         .optionally("Today")
         .optionally("RelativeDay")
@@ -546,7 +546,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .one_of("Query", "When")
         .require("Sunset")
-        .optionally("Location")
+        .optionally("location")
         .optionally("Today")
         .optionally("RelativeDay")
     )

--- a/__init__.py
+++ b/__init__.py
@@ -74,7 +74,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .optionally("query")
         .one_of("weather", "forecast")
-        .optionally("location")
+        .optionally("Location")
         .optionally("today")
     )
     def handle_current_weather(self, message: Message):
@@ -90,7 +90,7 @@ class WeatherSkill(MycroftSkill):
         .require("query")
         .require("like")
         .require("outside")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_like_outside(self, message: Message):
         """Handle current weather requests such as: what's it like outside?
@@ -105,7 +105,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .one_of("weather", "forecast")
         .require("number-days")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_number_days_forecast(self, message: Message):
         """Handle multiple day forecast without specified location.
@@ -130,7 +130,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .one_of("weather", "forecast")
         .require("relative-day")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_one_day_forecast(self, message):
         """Handle forecast for a single day.
@@ -149,7 +149,7 @@ class WeatherSkill(MycroftSkill):
         .require("query")
         .require("weather")
         .require("later")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_weather_later(self, message: Message):
         """Handle future weather requests such as: what's the weather later?
@@ -165,7 +165,7 @@ class WeatherSkill(MycroftSkill):
         .one_of("weather", "forecast")
         .require("relative-time")
         .optionally("relative-day")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_weather_at_time(self, message: Message):
         """Handle future weather requests such as: what's the weather tonight?
@@ -180,7 +180,7 @@ class WeatherSkill(MycroftSkill):
         .require("query")
         .one_of("weather", "forecast")
         .require("weekend")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_weekend_forecast(self, message: Message):
         """Handle requests for the weekend forecast.
@@ -195,7 +195,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .one_of("weather", "forecast")
         .require("week")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_week_weather(self, message: Message):
         """Handle weather for week (i.e. seven days).
@@ -209,7 +209,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .optionally("query")
         .require("temperature")
-        .optionally("location")
+        .optionally("Location")
         .optionally("unit")
         .optionally("today")
         .optionally("now")
@@ -231,7 +231,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .require("temperature")
         .require("relative-day")
-        .optionally("location")
+        .optionally("Location")
         .optionally("unit")
     )
     def handle_daily_temperature(self, message: Message):
@@ -250,7 +250,7 @@ class WeatherSkill(MycroftSkill):
         .require("temperature")
         .require("relative-time")
         .optionally("relative-day")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_hourly_temperature(self, message: Message):
         """Handle requests for current temperature at a relative time.
@@ -269,7 +269,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .require("high")
         .optionally("temperature")
-        .optionally("location")
+        .optionally("Location")
         .optionally("unit")
         .optionally("relative-day")
         .optionally("now")
@@ -292,7 +292,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .require("low")
         .optionally("temperature")
-        .optionally("location")
+        .optionally("Location")
         .optionally("unit")
         .optionally("relative-day")
         .optionally("now")
@@ -314,7 +314,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("confirm-query-current")
         .one_of("hot", "cold")
-        .optionally("location")
+        .optionally("Location")
         .optionally("today")
     )
     def handle_is_it_hot(self, message: Message):
@@ -330,7 +330,7 @@ class WeatherSkill(MycroftSkill):
         .optionally("query")
         .one_of("hot", "cold")
         .require("confirm-query")
-        .optionally("location")
+        .optionally("Location")
         .optionally("relative-day")
         .optionally("today")
     )
@@ -348,7 +348,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("confirm-query")
         .require("windy")
-        .optionally("location")
+        .optionally("Location")
         .optionally("relative-day")
     )
     def handle_is_it_windy(self, message: Message):
@@ -365,7 +365,7 @@ class WeatherSkill(MycroftSkill):
         .require("windy")
         .optionally("confirm-query")
         .optionally("relative-day")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_windy(self, message):
         """Handler for weather requests such as: how windy is it?
@@ -379,7 +379,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("confirm-query")
         .require("snow")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_is_it_snowing(self, message: Message):
         """Handler for weather requests such as: is it snowing today?
@@ -393,7 +393,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("confirm-query")
         .require("clear")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_is_it_clear(self, message: Message):
         """Handler for weather requests such as: is the sky clear today?
@@ -407,7 +407,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("confirm-query")
         .require("clouds")
-        .optionally("location")
+        .optionally("Location")
         .optionally("relative-time")
     )
     def handle_is_it_cloudy(self, message: Message):
@@ -419,7 +419,7 @@ class WeatherSkill(MycroftSkill):
         self._report_weather_condition(message, "clouds")
 
     @intent_handler(
-        IntentBuilder("").require("ConfirmQuery").require("Fog").optionally("location")
+        IntentBuilder("").require("ConfirmQuery").require("Fog").optionally("Location")
     )
     def handle_is_it_foggy(self, message: Message):
         """Handler for weather requests such as: is it foggy today?
@@ -430,7 +430,7 @@ class WeatherSkill(MycroftSkill):
         self._report_weather_condition(message, "fog")
 
     @intent_handler(
-        IntentBuilder("").require("ConfirmQuery").require("Rain").optionally("location")
+        IntentBuilder("").require("ConfirmQuery").require("Rain").optionally("Location")
     )
     def handle_is_it_raining(self, message: Message):
         """Handler for weather requests such as: is it raining today?
@@ -453,7 +453,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .require("ConfirmQuery")
         .require("Thunderstorm")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_is_it_storming(self, message: Message):
         """Handler for weather requests such as:  is it storming today?
@@ -468,7 +468,7 @@ class WeatherSkill(MycroftSkill):
         .require("When")
         .optionally("Next")
         .require("Precipitation")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_next_precipitation(self, message: Message):
         """Handler for weather requests such as: when will it rain next?
@@ -495,7 +495,7 @@ class WeatherSkill(MycroftSkill):
         .require("Query")
         .require("Humidity")
         .optionally("RelativeDay")
-        .optionally("location")
+        .optionally("Location")
     )
     def handle_humidity(self, message: Message):
         """Handler for weather requests such as: how humid is it?
@@ -520,7 +520,7 @@ class WeatherSkill(MycroftSkill):
     @intent_handler(
         IntentBuilder("")
         .one_of("Query", "When")
-        .optionally("location")
+        .optionally("Location")
         .require("Sunrise")
         .optionally("Today")
         .optionally("RelativeDay")
@@ -546,7 +546,7 @@ class WeatherSkill(MycroftSkill):
         IntentBuilder("")
         .one_of("Query", "When")
         .require("Sunset")
-        .optionally("location")
+        .optionally("Location")
         .optionally("Today")
         .optionally("RelativeDay")
     )

--- a/skill/dialog.py
+++ b/skill/dialog.py
@@ -38,7 +38,7 @@ from mycroft.util.format import join_list, nice_number, nice_time
 from mycroft.util.time import now_local
 from .config import WeatherConfig
 from .intent import WeatherIntent
-from .util import get_speakable_day_of_week, get_time_period
+from .util import get_speakable_day_of_week, get_time_period, get_tz_info
 from .weather import (
     CURRENT,
     CurrentWeather,
@@ -154,7 +154,7 @@ class CurrentDialog(WeatherDialog):
         if self.intent_data.location is None:
             now = now_local()
         else:
-            now = now_local(tz=self.intent_data.geolocation["timezone"])
+            now = now_local(tz=get_tz_info(self.intent_data.geolocation["timezone"]))
         if now < self.weather.sunrise:
             self.name += "-sunrise-future"
         else:
@@ -167,11 +167,11 @@ class CurrentDialog(WeatherDialog):
         if self.intent_data.location is None:
             now = now_local()
         else:
-            now = now_local(tz=self.intent_data.geolocation["timezone"])
+            now = now_local(tz=get_tz_info(self.intent_data.geolocation["timezone"]))
         if now < self.weather.sunset:
-            self.name += ".sunset.future"
+            self.name += "-sunset-future"
         else:
-            self.name = ".sunset.past"
+            self.name = "-sunset-past"
         self.data = dict(time=nice_time(self.weather.sunset))
         self._add_location()
 

--- a/skill/dialog.py
+++ b/skill/dialog.py
@@ -171,7 +171,7 @@ class CurrentDialog(WeatherDialog):
         if now < self.weather.sunset:
             self.name += "-sunset-future"
         else:
-            self.name = "-sunset-past"
+            self.name += "-sunset-past"
         self.data = dict(time=nice_time(self.weather.sunset))
         self._add_location()
 

--- a/skill/intent.py
+++ b/skill/intent.py
@@ -36,7 +36,7 @@ class WeatherIntent:
         :param language: The configured language of the device
         """
         self.utterance = message.data["utterance"]
-        self.location = message.data.get("location")
+        self.location = message.data.get("Location")
         self.language = language
         self.unit = message.data.get("unit")
         self.timeframe = CURRENT


### PR DESCRIPTION
### To reproduce:
issue a fog / sunrise report for a specific location ("is it foggy in New York")

__Problems:__ 
- Several intents (**condition/storm/rain/...**) have `.optionally("Location")` in their constructor while others go with `.optionally("location")`. This resulting in the location getting ignored.

- If you issue a **sunrise** request at a specific location `now = now_local(tz=self.intent_data.geolocation["timezone"])` throws an exception
```
Traceback (most recent call last):
  File "/home/sweng/mycroft-core/mycroft/skills/mycroft_skill/event_container.py", line 73, in wrapper
    handler(message)
  File "/opt/mycroft/skills/skill-weather.emphasize/__init__.py", line 565, in handle_sunset
    dialog.build_sunset_dialog()
  File "/opt/mycroft/skills/skill-weather.emphasize/skill/dialog.py", line 170, in build_sunset_dialog
    now = now_local(tz=self.intent_data.geolocation["timezone"])
  File "/home/sweng/mycroft-core/mycroft/util/time.py", line 68, in now_local
    return datetime.now(tz)
TypeError: tzinfo argument must be None or of a tzinfo subclass, not type 'str'
```  

- Typo in dialog string constructor for **sunrise/sunset** `self.name += ".sunset.future"` (should be `"-sunset-future"`) 


#### What this PR does
- all location adapt intent construction strings are ~~lower case~~ capitalized
- dialog.py imports `get_tz_info` from skill.util to convert the timezone string
- Fixes the sunset/sunrise dialog construction


#### Type of PR
- [x] Bugfix


- [x] __CLA__