### PR TITLE
Handle a request for current local weather without an intent

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,7 +53,6 @@ from .skill import (
 #   Later weather: only the word "later" in the vocab file works all others
 #       invoke datetime skill
 
-FIFTEEN_MINUTES = 900
 MARK_II = "mycroft_mark_2"
 TWELVE_HOUR = "half"
 
@@ -464,9 +463,9 @@ class WeatherSkill(MycroftSkill):
     def handle_is_it_raining(self, message: Message):
         """Handler for weather requests such as: is it raining today?
 
-                Args:
-                    message: Message Bus event information from the intent parser
-        0]"""
+        Args:
+            message: Message Bus event information from the intent parser
+        """
         self._report_weather_condition(message, "rain")
 
     @intent_handler("do-i-need-an-umbrella.intent")

--- a/__init__.py
+++ b/__init__.py
@@ -71,9 +71,11 @@ class WeatherSkill(MycroftSkill):
     def initialize(self):
         """Do these things after the skill is loaded."""
         self.weather_config = WeatherConfig(self.config_core, self.settings)
-        self.add_event("skill.weather.request-local", self.handle_get_local_weather)
+        self.add_event(
+            "skill.weather.request-local-forecast", self.handle_get_local_forecast
+        )
 
-    def handle_get_local_weather(self, _):
+    def handle_get_local_forecast(self, _):
         """Handles a message bus command requesting current local weather information.
 
         Such a request will typically come from a domain external to this skill that
@@ -86,7 +88,8 @@ class WeatherSkill(MycroftSkill):
                 system_unit, self.weather_config.latitude, self.weather_config.longitude
             )
         except Exception:
-            self.log.exception("Unexpected error getting weather for skill API.")
+            self.log.exception("Unexpected error getting weather.")
+            self.bus.emit(Message("skill.weather.local-forecast-failure."))
         else:
             self._emit_local_weather_response(weather)
 
@@ -101,7 +104,7 @@ class WeatherSkill(MycroftSkill):
             temperature=weather.current.temperature,
             weather_condition=weather_condition_url,
         )
-        event = Message("skill.weather.local-retrieved", data=event_data)
+        event = Message("skill.weather.local-forecast-obtained", data=event_data)
         self.bus.emit(event)
 
     @intent_handler(


### PR DESCRIPTION
#### Description
Handles a new `skill.weather.request-local` command from the message bus that gets the local weather forecast without using the intent system. Once the weather data is retrieved, a `skill.weather.local-retrieved` event is emitted over the message bus.  The initial use case for this is the Home Screen skill, which displays and weather condition icon and temperature.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [ ] Bugfix
- [X] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Use a message bus client to request the current local weather and listen for the response.

#### Documentation
Docstrings for new methods included.
