### PR TITLE
Bugfix/sunset time

### DIFF
--- a/skill/dialog.py
+++ b/skill/dialog.py
@@ -169,9 +169,9 @@ class CurrentDialog(WeatherDialog):
         else:
             now = now_local(tz=self.intent_data.geolocation["timezone"])
         if now < self.weather.sunset:
-            self.name += ".sunset.future"
+            self.name += "-sunset-future"
         else:
-            self.name = ".sunset.past"
+            self.name += "-sunset-past"
         self.data = dict(time=nice_time(self.weather.sunset))
         self._add_location()
 

--- a/skill/util.py
+++ b/skill/util.py
@@ -32,8 +32,7 @@ class LocationNotFoundError(ValueError):
 def convert_to_local_datetime(timestamp: time, timezone: str) -> datetime:
     """Convert a timestamp to a datetime object in the requested timezone.
 
-    This function assumes it is passed a timestamp in the UTC timezone.  It
-    then adjusts the datetime to match the specified timezone.
+    The timestamp as represented by seconds since epoch is inherently UTC.
 
     Args:
         timestamp: seconds since epoch
@@ -42,8 +41,7 @@ def convert_to_local_datetime(timestamp: time, timezone: str) -> datetime:
     Returns:
         A datetime in the passed timezone based on the passed timestamp
     """
-    naive_datetime = datetime.fromtimestamp(timestamp)
-    utc_datetime = pytz.utc.localize(naive_datetime)
+    utc_datetime = datetime.utcfromtimestamp(timestamp)
     local_timezone = pytz.timezone(timezone)
     local_datetime = utc_datetime.astimezone(local_timezone)
 


### PR DESCRIPTION
#### Description
This fixes two issues:
1. The name of the sunset and sunrise dialogs was using periods instead of the new dashes
2. On systems where the system clock had it's timezone set to non-UTC, the sunrise and sunset times were incorrectly reported.
  `datetime.fromtimestamp` by default will return a local time but was being treated as a UTC time.

#### Type of PR
- [x] Bugfix

#### Testing
Run Mycroft on a regular desktop (your clock is most likely set correctly) ask "what time is the sunset"

#### CLA
- [x] Yes