### PR TITLE
handle STT engine returning a hyphenated day duration (i.e. 3-day)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -159,7 +159,10 @@ class WeatherSkill(MycroftSkill):
         elif self.voc_match(message.data["utterance"], "few"):
             days = 3
         else:
-            days = int(extract_number(message.data["utterance"]))
+            # Some STT engines hyphenate the day count (i.e. 3-day).  This is not
+            # handled by extract_number() so remove the hyphen if it is there.
+            utterance = message.data["utterance"].replace("-day", " day")
+            days = int(extract_number(utterance))
         self._report_multi_day_forecast(message, days)
 
     @intent_handler(

--- a/locale/en-us/vocabulary/date-time/number-days.voc
+++ b/locale/en-us/vocabulary/date-time/number-days.voc
@@ -1,22 +1,32 @@
-2 day
-two day
+2-day
+two-day
+2 day(s|)
+two day(s|)
 next 2 days
 next two days
 next couple of days
 next couple days
-3 day
-three day
+3-day
+three-day
+3 day(s|)
+three day(s|)
 next 3 days
 next three days
 next few days
-4 day
+4-day
+four-day
+4 day(s|)
 four day(s|)
 next 4 days
 next four days
-5 days
-five day
+5-day
+five-day
+5 day(s|)
+five day(s|)
 next 5 days
 next five days
+6-day
+six-day
 6 day(s|)
 six day(s|)
 next 6 days

--- a/test/behave/daily-weather-local.feature
+++ b/test/behave/daily-weather-local.feature
@@ -23,3 +23,17 @@ Feature: Mycroft Weather Skill local daily forecasts
     | what is the weather like on saturday |
     | what is the weather like monday |
     | what is the weather like in 5 days from now |
+
+  Scenario Outline: multiple day forecast
+    Given an english speaking user
+     When the user says "<multiple day forecast request>"
+     Then "mycroft-weather" should reply with dialog from "daily-weather-local.dialog"
+     Then "mycroft-weather" should reply with dialog from "daily-weather-local.dialog"
+     Then "mycroft-weather" should reply with dialog from "daily-weather-local.dialog"
+
+  Examples: what is the forecast for a future date
+    | multiple day forecast request |
+    | what is the forecast for the next three days |
+    | what is the weather forecast for the next three days |
+    | what is the three-day weather forecast |
+    | for the next three days what is the weather forecast |


### PR DESCRIPTION
#### Description
Some STT engines (specifically the default engine used by Mycroft) return a hyphenated day duration (I.e. 3-day).  This was not in the `number-days.voc` file.  The result was triggering of the current weather intent rather than the multiple day intent.

The `extract_number()` function does not handle the hyphen well either, so it is removed before calling the function.

Multiple day forecast conditions were also added to the VK tests.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Ask Mycroft for a 3-day forecast.

#### Documentation
N/A
