### PR TITLE
added "today" vocabulary to some intents to fix failing VK tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -128,6 +128,7 @@ class WeatherSkill(MycroftSkill):
         .require("like")
         .require("outside")
         .optionally("location")
+        .optionally("today")
     )
     def handle_like_outside(self, message: Message):
         """Handle current weather requests such as: what's it like outside?
@@ -190,6 +191,7 @@ class WeatherSkill(MycroftSkill):
         .require("weather")
         .require("later")
         .optionally("location")
+        .optionally("today")
     )
     def handle_weather_later(self, message: Message):
         """Handle future weather requests such as: what's the weather later?
@@ -453,7 +455,7 @@ class WeatherSkill(MycroftSkill):
         self._report_weather_condition(message, "clouds")
 
     @intent_handler(
-        AdaptIntent().require("ConfirmQuery").require("Fog").optionally("location")
+        AdaptIntent().require("confirm-query").require("fog").optionally("location")
     )
     def handle_is_it_foggy(self, message: Message):
         """Handler for weather requests such as: is it foggy today?
@@ -464,7 +466,7 @@ class WeatherSkill(MycroftSkill):
         self._report_weather_condition(message, "fog")
 
     @intent_handler(
-        AdaptIntent().require("ConfirmQuery").require("Rain").optionally("location")
+        AdaptIntent().require("confirm-query").require("rain").optionally("location")
     )
     def handle_is_it_raining(self, message: Message):
         """Handler for weather requests such as: is it raining today?
@@ -485,9 +487,9 @@ class WeatherSkill(MycroftSkill):
 
     @intent_handler(
         AdaptIntent()
-        .require("ConfirmQuery")
-        .require("Thunderstorm")
-        .optionally("Location")
+        .require("confirm-query")
+        .require("thunderstorm")
+        .optionally("location")
     )
     def handle_is_it_storming(self, message: Message):
         """Handler for weather requests such as:  is it storming today?
@@ -499,10 +501,10 @@ class WeatherSkill(MycroftSkill):
 
     @intent_handler(
         AdaptIntent()
-        .require("When")
-        .optionally("Next")
-        .require("Precipitation")
-        .optionally("Location")
+        .require("when")
+        .optionally("next")
+        .require("precipitation")
+        .optionally("location")
     )
     def handle_next_precipitation(self, message: Message):
         """Handler for weather requests such as: when will it rain next?
@@ -526,10 +528,10 @@ class WeatherSkill(MycroftSkill):
 
     @intent_handler(
         AdaptIntent()
-        .require("Query")
-        .require("Humidity")
-        .optionally("RelativeDay")
-        .optionally("Location")
+        .require("query")
+        .require("humidity")
+        .optionally("relative-day")
+        .optionally("location")
     )
     def handle_humidity(self, message: Message):
         """Handler for weather requests such as: how humid is it?
@@ -553,11 +555,11 @@ class WeatherSkill(MycroftSkill):
 
     @intent_handler(
         AdaptIntent()
-        .one_of("Query", "When")
-        .optionally("Location")
-        .require("Sunrise")
-        .optionally("Today")
-        .optionally("RelativeDay")
+        .one_of("query", "when")
+        .optionally("location")
+        .require("sunrise")
+        .optionally("today")
+        .optionally("relative-day")
     )
     def handle_sunrise(self, message: Message):
         """Handler for weather requests such as: when is the sunrise?
@@ -578,11 +580,11 @@ class WeatherSkill(MycroftSkill):
 
     @intent_handler(
         AdaptIntent()
-        .one_of("Query", "When")
-        .require("Sunset")
-        .optionally("Location")
-        .optionally("Today")
-        .optionally("RelativeDay")
+        .one_of("query", "when")
+        .require("sunset")
+        .optionally("location")
+        .optionally("today")
+        .optionally("relative-day")
     )
     def handle_sunset(self, message: Message):
         """Handler for weather requests such as: when is the sunset?

--- a/test/behave/current-weather-local.feature
+++ b/test/behave/current-weather-local.feature
@@ -28,13 +28,4 @@ Feature: Mycroft Weather Skill local current weather conditions
     | how is the weather now |
     | what is it like outside right now |
     | what's it like outside |
-
-  @xfail
-  Scenario Outline: Current local weather matches date/time relative day intent
-    Given an english speaking user
-     When the user says "<current local weather>"
-     Then "mycroft-weather" should reply with dialog from "current-weather-local.dialog"
-
-  Examples: What is the current local weather
-    | current local weather |
     | what's it like outside today |

--- a/test/behave/current-weather-location.feature
+++ b/test/behave/current-weather-location.feature
@@ -17,6 +17,7 @@ Feature: Mycroft Weather Skill current weather at a specified location
     | what is it like outside in italy |
     | In tokyo what is it like outside |
     | how is the weather in new york city |
+    | what is it like outside in baltimore today |
 
 
   @xfail
@@ -28,7 +29,6 @@ Feature: Mycroft Weather Skill current weather at a specified location
   Examples: what is the current local weather in a location
     | what is the current weather in location |
     | what's the current weather conditions in Washington, D.C. |
-    | what is it like outside in baltimore today |
 
 
   Scenario Outline: User asks for the current weather in an unknown location

--- a/test/behave/daily-weather-local.feature
+++ b/test/behave/daily-weather-local.feature
@@ -22,7 +22,7 @@ Feature: Mycroft Weather Skill local daily forecasts
     | what is the weather like tuesday |
     | what is the weather like on saturday |
     | what is the weather like monday |
-    | what is the weather like in 5 days from now |
+    | what is the weather like 5 days from now |
 
   Scenario Outline: multiple day forecast
     Given an english speaking user

--- a/test/behave/hourly-weather-local.feature
+++ b/test/behave/hourly-weather-local.feature
@@ -8,13 +8,4 @@ Feature: Mycroft Weather Skill local hourly forecasts
   Examples: What is the weather later
     | what is the weather later |
     | what is the weather later |
-
-  @xfail
-  Scenario Outline: Failing - what is the weather later
-    Given an english speaking user
-     When the user says "<failing - what is the weather later>"
-     Then "mycroft-weather" should reply with dialog from "hourly-weather-local.dialog"
-
-  Examples: Failing - What is the weather later
-    | failing - what is the weather later |
     | what's the weather later today |

--- a/test/behave/hourly-weather-location.feature
+++ b/test/behave/hourly-weather-location.feature
@@ -8,13 +8,4 @@ Feature: Mycroft Weather Skill hourly forecasts at a specified location
   Examples: What is the weather later
     | what is the weather later |
     | what is the weather in Baltimore later |
-
-  @xfail
-  Scenario Outline: User asks what the weather is later at a location
-    Given an english speaking user
-     When the user says "<what is the weather later>"
-     Then "mycroft-weather" should reply with dialog from "hourly-weather-location.dialog"
-
-  Examples: What is the weather later
-    | what is the weather later |
     | what is the weather in London later today |


### PR DESCRIPTION

### How to use this template
Under each heading below is a short outline of the information required. When submitting a PR, please delete this text and replace it with your own. 

The CLA section can be deleted entirely.

#### Description
Some VK tests were failing since the "today" vocabulary was added to the current weather intent.  Some utterances in the tests used the word "today", which caused a better match with the current weather intent than with the intent it was meant to match.  Added "today" to other intents to balance things out.

Also changed some other intents to match new vocabulary file naming convention

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
All VK tests should pass (except for two remaining `@xfail` tests).

#### Documentation
N/A
