### PR TITLE
Fix Error in query for humidity

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -546,8 +546,9 @@ class WeatherSkill(MycroftSkill):
             dialog = get_dialog_for_timeframe(intent_data.timeframe, dialog_args)
             dialog.build_humidity_dialog()
             dialog.data.update(
-                humidity=self.translate(
-                    "percentage-number", data=dict(num=dialog.data["humidity"])
+                percent=self.translate(
+                    "percentage-number",
+                    data=dict(number=dialog.data["percent"])
                 )
             )
             self._speak_weather(dialog)

--- a/test/behave/current-humidity-local.feature
+++ b/test/behave/current-humidity-local.feature
@@ -1,0 +1,15 @@
+Feature: Mycroft Weather Skill current local humidity
+
+  Scenario Outline: What is the humidity today
+    Given an english speaking user
+     When the user says "<what is the humidity today>"
+     Then "mycroft-weather" should reply with dialog from "current-humidity-local.dialog"
+
+  Examples: What is the humidity today
+    | what is the humidity today |
+    | what is the humidity today |
+    | what's the humidity |
+    | what will be the humidity today |
+    | how humid is it |
+    | how humid is it outside |
+


### PR DESCRIPTION
#### Description
The skill fails with errors for queries like "what is the humidity today".

This fixes the usage of the dialog data for generating spoken report from humidity. previously it used the wrong member in the data structure in the dialog object.

This only corrects the member names used when getting data from dialog object and when entering into the humidity speak_dialog. (And adds a basic set of tests for the query)

#### Type of PR

- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Check that the new vk tests for the skill passes