### PR TITLE
Fix Error for "when will it snow" query if no precipitation is forecasted

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -519,10 +519,12 @@ class WeatherSkill(MycroftSkill):
             dialog_args = intent_data, self.weather_config, forecast
             dialog = get_dialog_for_timeframe(intent_data.timeframe, dialog_args)
             dialog.build_next_precipitation_dialog()
-            spoken_percentage = self.translate(
-                "percentage-number", data=dict(number=dialog.data["percent"])
-            )
-            dialog.data.update(percent=spoken_percentage)
+            if "percent" in dialog.data:
+                spoken_percentage = self.translate(
+                    "percentage-number",
+                    data=dict(number=dialog.data["percent"])
+                )
+                dialog.data.update(percent=spoken_percentage)
             self._speak_weather(dialog)
 
     @intent_handler(


### PR DESCRIPTION
#### Description
This will not perform translation of percentage when the result doesn't
contain percentage to translate.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Try asking "when will it snow" in a location that has no precipitation forecasted and make sure no error occurs. And make sure that a location that has forecasted precipitation will still report correctly.