### PR TITLE
Add missing weather icon codes

### DIFF
--- a/skill/weather.py
+++ b/skill/weather.py
@@ -40,31 +40,31 @@ SUNDAY = 6
 ICON_IMAGE_MAP = (
     (("01d",), "sun.svg"),
     (("01n",), "moon.svg"),
-    (("04d", "04n"), "clouds.svg"),
-    (("50d",), "fog.svg"),
     (("02d", "03d"), "partial_clouds_day.svg"),
     (("02n", "03n"), "partial_clouds_night.svg"),
-    (("09d", "10d"), "rain.svg"),
-    (("13d",), "snow.svg"),
-    (("11d",), "storm.svg"),
+    (("04d", "04n"), "clouds.svg"),
+    (("09d", "10d", "09n", "10n"), "rain.svg"),
+    (("11d", "11n"), "storm.svg"),
+    (("13d", "13n"), "snow.svg"),
+    (("50d", "50n"), "fog.svg"),
 )
 ICON_ANIMATION_MAP = (
     (("01d", "01n"), "sun.json"),
-    (("04d", "04n"), "clouds.json"),
-    (("50d",), "fog.json"),
     (("02d", "03d", "02n", "03n"), "partial_clouds.json"),
-    (("09d", "10d"), "rain.json"),
-    (("13d",), "snow.json"),
-    (("11d",), "storm.json"),
+    (("04d", "04n"), "clouds.json"),
+    (("09d", "10d", "09n", "10n"), "rain.json"),
+    (("11d", "11n"), "storm.json"),
+    (("13d", "13n"), "snow.json"),
+    (("50d", "50n"), "fog.json"),
 )
 ICON_CODE_MAP = (
     (("01d", "01n"), 0),
-    (("04d", "04n"), 2),
-    (("50d",), 7),
     (("02d", "03d", "02n", "03n"), 1),
-    (("09d", "10d"), 3),
-    (("13d",), 6),
-    (("11d",), 5),
+    (("04d", "04n"), 2),
+    (("09d", "10d", "09n", "10n"), 3),
+    (("11d", "11n"), 5),
+    (("13d", "13n"), 6),
+    (("50d", "50n"), 7),
 )
 
 THIRTY_PERCENT = 30


### PR DESCRIPTION
#### Description
Possible resolution of #187
Weather code mappings were missing 'night' versions of some conditions. This adds all codes listed in the OWM API docs and reorders the sets in numeric order

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [x] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Getting a forecast of rain after sunset should now produce an icon where previously no icon was returned.

#### Documentation
No changes to expected behavior

#### CLA
To protect you, the project, and those who choose to use Mycroft technologies in systems they build, we ask all contributors to sign a Contributor License Agreement.

This agreement clarifies that you are granting a license to the Mycroft Project to freely use your work.  Additionally, it establishes that you retain the ownership of your contributed code and intellectual property.  As the owner, you are free to use your code in other work, obtain patents, or do anything else you choose with it.

If you haven't already signed the agreement and been added to our public [Contributors repo](https://github.com/mycroftAI/contributors) then please head to https://mycroft.ai/cla to initiate the signing process.
