### PR TITLE
Add missing dialog for hourly-wind-*

### DIFF
--- a/locale/en-us/dialog/hourly/hourly-wind-light-local.dialog
+++ b/locale/en-us/dialog/hourly/hourly-wind-light-local.dialog
@@ -1,0 +1,2 @@
+At {time} there will be a light wind coming from the {direction} at {speed} {speed_unit}
+At {time} it will not be very windy

--- a/locale/en-us/dialog/hourly/hourly-wind-light-location.dialog
+++ b/locale/en-us/dialog/hourly/hourly-wind-light-location.dialog
@@ -1,0 +1,2 @@
+At {time} there will be a light wind coming from the {direction} in {location} at {speed} {speed_unit}
+At {time} it will not be very windy in {location}

--- a/locale/en-us/dialog/hourly/hourly-wind-moderate-local.dialog
+++ b/locale/en-us/dialog/hourly/hourly-wind-moderate-local.dialog
@@ -1,0 +1,3 @@
+At {time} the wind will be moderate, about {speed} {speed_unit} from the {direction}
+The forecast calls for a moderate wind from the {direction} at {speed} {speed_unit}
+At {time} You can expect a moderate wind of about {speed} {speed_unit}

--- a/locale/en-us/dialog/hourly/hourly-wind-moderate-location.dialog
+++ b/locale/en-us/dialog/hourly/hourly-wind-moderate-location.dialog
@@ -1,0 +1,3 @@
+At {time} The wind will be moderate in {location}, about {speed} {speed_unit} from the {direction}
+The forecast for {time} predicts {location} will have moderate wind from the {direction} of {speed} {speed_unit}
+You can expect a wind of about {speed} {speed_unit} in {location} at {time}

--- a/locale/en-us/dialog/hourly/hourly-wind-strong-local.dialog
+++ b/locale/en-us/dialog/hourly/hourly-wind-strong-local.dialog
@@ -1,0 +1,2 @@
+At {time} there will be strong wind from the {direction} of {speed} {speed_unit}
+At {time} the wind will be as strong as {speed} {speed_unit}

--- a/locale/en-us/dialog/hourly/hourly-wind-strong-location.dialog
+++ b/locale/en-us/dialog/hourly/hourly-wind-strong-location.dialog
@@ -1,0 +1,2 @@
+There will be a strong wind from the {direction} of {speed} {speed_unit} in {location} at {time}
+At {time} the wind will be as strong as {speed} {speed_unit} in {location}


### PR DESCRIPTION
#### Description
No dialog was present for hourly-wind reporting so "how windy will it be tonight" just gave hourly-wind-light-local as answer.

This adds the missing dialog files.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Test that "how windy will it be tonight" produces a valid response.